### PR TITLE
Add object-fit: cover to playlist covers

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -121,6 +121,7 @@ view) */
     width:180px;
     height:180px;
     margin-bottom:10px;
+    object-fit:cover;
 }
 
 .playlist-box {


### PR DESCRIPTION
Some playlist images are not square, due to the playlist annotation feature not cropping it. Thus, some images look stretched.
While traditionally this has been fixes using a square div with a background image whose size is set to cover, this can now be fixed more easily using `object-fit: cover` in [supported browsers](http://caniuse.com/#feat=object-fit).

Stretched:
![stretched](https://cloud.githubusercontent.com/assets/416456/7136118/acc3beaa-e2ad-11e4-9e2f-0b350e484124.png)

Using object-fit: cover:
![fit](https://cloud.githubusercontent.com/assets/416456/7136122/c248987c-e2ad-11e4-9b27-9d5067a4debb.png)
